### PR TITLE
fix for puzzling logo disappearance.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,7 +21,7 @@
     <div class="container">
       <div class="grid">
         <div class="unit one-third">
-          <a href="{{ site.baseurl }}/" class="site-avatar"><img src="/images/watir_logo.png"/></a>
+          <a href="{{ site.baseurl }}/" class="site-avatar"><img src="/images/Watir_logo.png"/></a>
           <span id="powered-by">Powered by Selenium</span>
         </div>
       </div>


### PR DESCRIPTION
I renamed Watir_logo.png to watir_logo.png (both file and reference) for lowercase consistency in the html, but git didn't pick up the change to the filename, so I reverted, and changed the reference back to uppercase. Figuring out how to get git to pick up filename changes now.