### PR TITLE
Remove 2010 "demo" for news pages

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -7,7 +7,7 @@ title: Watir News
 
 {% for post in site.posts %}
 {% capture year %}{{post.date | date: "%Y"}}{% endcapture %}
-{% if year == "2010" %}
+{% if year == "2016" %}
 <li>
     <strong><a href="{{ post.url }}">{{ post.title }}</a></strong>
     <p>

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@ title: Watir is...
 
   {% for post in site.posts %}
   {% capture year %}{{post.date | date: "%Y"}}{% endcapture %}
-  {% if year == "2010" %}
+  {% if year == "2016" %}
   <li>
     <strong><a href="{{ post.url }}">{{ post.title }}</a></strong>
     <p>


### PR DESCRIPTION
What is in master is for demo only. This is the fix we need before releasing.