### PR TITLE
Update watir-release.md: fix a broken link

### DIFF
--- a/_posts/2016-08-02-watir-release.md
+++ b/_posts/2016-08-02-watir-release.md
@@ -8,18 +8,18 @@ comments: true
 categories: [Releases]
 ---
 
-Watir-WebDriver 0.9.2 and 0.9.3 (which is a minor bug fix to 0.9.2) have been released! 
-Alex did some great work on this one, with significant updates to element locator implementation. 
- 
+Watir-WebDriver 0.9.2 and 0.9.3 (which is a minor bug fix to 0.9.2) have been released!
+Alex did some great work on this one, with significant updates to element locator implementation.
+
 <!--more-->
 
-[Read the full Changelog](https://github.comwatir/watir/blob/master/CHANGES.md).
+[Read the full Changelog](https://github.com/watir/watir/blob/master/CHANGES.md).
 
-The previous `ElementLocator` class 
-was very unwieldy, so it has been broken up for better separation of concerns. 
+The previous `ElementLocator` class
+was very unwieldy, so it has been broken up for better separation of concerns.
 Now building the selector and validating a found element are no longer coupled to
 the actual locating functionality.
 
 The huge ramification of this change is that the means of locating elements is now
-extensible from outside the project. An example implementation of this is 
+extensible from outside the project. An example implementation of this is
 [Watizzle](https://github.com/p0deje/watizzle).


### PR DESCRIPTION
- missing forward slash in a "Read the full Changelog" link