### PR TITLE
Update the link to chromedriver to specify a newer version.

### DIFF
--- a/_docs/chrome.md
+++ b/_docs/chrome.md
@@ -6,7 +6,7 @@ permalink: /docs/chrome/
 
 ### ChromeDriver
 
-Chrome support is through the platform specific ChromeDriver binary, which you [download](http://chromedriver.storage.googleapis.com/index.html) and put on your path.
+Chrome support is through the platform specific ChromeDriver binary, which you [download](https://sites.google.com/a/chromium.org/chromedriver/downloads) and put on your path.
 {% highlight ruby %}
 b = Watir::Browser.new :chrome
 {% endhighlight %}


### PR DESCRIPTION
Hey there, 
using watir-webdriver with Chrome I ran into the following error:

``` selenium-webdriver-3.0.0/lib/selenium/webdriver/remote/response.rb:69:in
`assert_ok': unknown error: Runtime.executionContextCreated has invalid
'context': {"auxData":{"frameId":"20718.1","isDefault":true},"id":1,"name":"","o
rigin":"://"} (Selenium::WebDriver::Error::UnknownError)   (Session info:
chrome=54.0.2840.87)
```

This was also reported here: http://stackoverflow.com/questions/40235380
/protractor-selenium-webdriver-runtime-executioncontextcreated-has-invalid-c

Getting the chromedriver v 2.25 and putting it on my path fixed this issue for
me. However the documentation currently links to
http://chromedriver.storage.googleapis.com/index.html. This could mislead one to
download version 2.9, which worked previous to updating to selenium-webdriver
3.0.0.

This commit links directly to v 2.25. Alternatively the link could go here:

https://sites.google.com/a/chromium.org/chromedriver/downloads