### PR TITLE
Update Stack Overflow link to use Watir tag

### DIFF
--- a/help.md
+++ b/help.md
@@ -4,7 +4,7 @@ title: Help
 ---
 
 ### The best way to get help with Watir:
-[Post a Question on StackOverflow](http://stackoverflow.com/questions/tagged/watir-webdriver)
+[Post a Question on StackOverflow](http://stackoverflow.com/questions/tagged/watir)
 
 ### Alternate ways to get help:
 Send a question to the [Watir-General](https://groups.google.com/forum/#!forum/watir-general) mailing list on Google Groups. Please read these [guidelines](https://github.com/watir/watir_meta/wiki/Guidelines-for-Posting-to-Watir-General-Google-Group) before posting.


### PR DESCRIPTION
The Help page links to the Watir-Webdriver tag on Stack Overflow. Given that we have deprecated Watir-Webdriver, the Watir tag should be used.

Note that the link in the footer already links to the Watir tag.