### PR TITLE
Demo update to use watir.com instead of google.com

### DIFF
--- a/_includes/demo.html
+++ b/_includes/demo.html
@@ -1,11 +1,10 @@
 {% highlight ruby %}
 browser = Watir::Browser.new :chrome
 
-browser.goto 'google.com'
-browser.text_field(title: 'Search').set 'Hello World!'
-browser.button(type: 'submit').click
+browser.goto 'watir.com'
+browser.link(text: 'Documentation').click
 
 puts browser.title
-# => 'Hello World! - Google Search'
-browser.quit
+# => 'Documentation – Watir Project...'
+browser.close
 {% endhighlight %}


### PR DESCRIPTION
Google recently changed their search page, and the existing demo no longer works correctly. This update isn't as involved as the existing one, but it utilizes watir.com, thus removing the demo's dependency on Google.

Opening a similar PR on watir/watir changing the main demo there, too!