### PR TITLE
Geckodriver mention

### DIFF
--- a/_docs/firefox.md
+++ b/_docs/firefox.md
@@ -6,7 +6,7 @@ permalink: /docs/firefox/
 
 ### It Just Works™
 
-Firefox is supported through a JavaScript driver, therefore ‘it just works™’ on all platforms.
+Firefox is supported through a JavaScript driver, therefore ‘it just works™’ on all platforms provided you've installed [https://github.com/mozilla/geckodriver/releases](geckodriver).
 
 {% highlight ruby %}
 b = Watir::Browser.new :firefox

--- a/_includes/demo.html
+++ b/_includes/demo.html
@@ -1,11 +1,10 @@
 {% highlight ruby %}
 browser = Watir::Browser.new :chrome
 
-browser.goto 'google.com'
-browser.text_field(title: 'Search').set 'Hello World!'
-browser.button(type: 'submit').click
+browser.goto 'watir.com'
+browser.link(text: 'Documentation').click
 
 puts browser.title
-# => 'Hello World! - Google Search'
-browser.quit
+# => 'Documentation – Watir Project...'
+browser.close
 {% endhighlight %}


### PR DESCRIPTION
Even though FF 'just works' you still need geckodriver. Thanks to @samnissen for pointing this out in [watir's 528](https://github.com/watir/watir/issues/528)!